### PR TITLE
Comment out unit test exclude block in build.gradle

### DIFF
--- a/vkq_library/vkquality/build.gradle.kts
+++ b/vkq_library/vkquality/build.gradle.kts
@@ -64,13 +64,13 @@ android {
         prefab = true
     }
 // Comment out this packaging block if you are building with unit tests enabled
-    packaging {
+//    packaging {
         // use the jniLibs block to exclude .so files.
-        jniLibs {
-            testOnly += "**/libvkq_tests.so"
-            testOnly += "**/libc++_shared.so"
-        }
-    }
+//        jniLibs {
+//            testOnly += "**/libvkq_tests.so"
+//            testOnly += "**/libc++_shared.so"
+//        }
+//    }
 }
 
 dependencies {


### PR DESCRIPTION
Disable unit test library exclude block to avoid build error if you don't have the scaffolding set up.