### PR TITLE
Update library to 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ feedback will help refine the recommendation list.
 
 ## Version history
 
+* 1.2.1 - (04/14/2025) - Rebuilt library to be compatible with 16Kb page size
+Android devices. Added `vkQuality_initializeFlagsInfo` alternative init function
+for C/C++ users passing their own graphics device information instead of VkQuality
+standing up graphics API instances to query.
 * 1.2 - (12/03/2024) - Added additional quality signal source option, derived from
 pairs of SoC names and driver fingerprint strings. This signal check can be disabled
 using a new `INIT_FLAG_SKIP_DRIVER_FINGERPRINT_CHECK` flag.

--- a/vkq_library/vkquality/build.gradle.kts
+++ b/vkq_library/vkquality/build.gradle.kts
@@ -26,6 +26,7 @@ plugins {
 android {
     namespace = "com.google.android.games.vkquality"
     compileSdk = 35
+    ndkVersion = "27.2.12479018"
 
     defaultConfig {
         minSdk = 22
@@ -36,6 +37,7 @@ android {
             cmake {
                 cppFlags("-std=c++17")
                 arguments += "-DANDROID_STL=c++_static"
+                arguments += "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
             }
         }
     }

--- a/vkq_library/vkquality/src/main/cpp/vkquality_c.cpp
+++ b/vkq_library/vkquality/src/main/cpp/vkquality_c.cpp
@@ -22,7 +22,7 @@ extern "C" {
 
 #define VKQUALITY_MAJOR_VERSION 1
 #define VKQUALITY_MINOR_VERSION 2
-#define VKQUALITY_BUGFIX_VERSION 0
+#define VKQUALITY_BUGFIX_VERSION 1
 
 #define VKQUALITY_GENERATE_PACKED_VERSION(MAJOR, MINOR, BUGFIX) \
     ((MAJOR << 16) | (MINOR << 8) | (BUGFIX))
@@ -51,7 +51,8 @@ uint32_t VkQuality_getVersion() {
 vkQualityInitResult vkQuality_initialize(JNIEnv *env, AAssetManager *asset_manager,
                                          const char *storage_path,
                                          const char *asset_filename) {
-  return vkquality::VkQualityManager::Init(env, asset_manager, storage_path, asset_filename, 0);
+  return vkquality::VkQualityManager::Init(env, asset_manager, storage_path, asset_filename,
+                                           nullptr, 0);
 }
 
 vkQualityInitResult vkQuality_initializeFlags(JNIEnv *env, AAssetManager *asset_manager,
@@ -59,7 +60,16 @@ vkQualityInitResult vkQuality_initializeFlags(JNIEnv *env, AAssetManager *asset_
                                          const char *asset_filename,
                                          int32_t flags) {
     return vkquality::VkQualityManager::Init(env, asset_manager, storage_path, asset_filename,
-                                             flags);
+                                             nullptr, flags);
+}
+
+vkQualityInitResult vkQuality_initializeFlagsInfo(JNIEnv *env, AAssetManager *asset_manager,
+  const char *storage_path,
+  const char *asset_filename,
+  const vkqGraphicsAPIInfo *api_info,
+  int32_t flags) {
+    return vkquality::VkQualityManager::Init(env, asset_manager, storage_path, asset_filename,
+                                             api_info, flags);
 }
 
 void vkQuality_destroy(JNIEnv *env) {

--- a/vkq_library/vkquality/src/main/cpp/vkquality_manager.h
+++ b/vkq_library/vkquality/src/main/cpp/vkquality_manager.h
@@ -48,7 +48,8 @@ class VkQualityManager {
 
  public:
   VkQualityManager(JNIEnv *env, AAssetManager *asset_manager,
-                   const char *storage_path, const char *asset_filename, int32_t flags,
+                   const char *storage_path, const char *asset_filename, 
+                   const vkqGraphicsAPIInfo *api_info, int32_t flags,
                    ConstructorTag);
 
   ~VkQualityManager() = default;
@@ -56,6 +57,7 @@ class VkQualityManager {
   static vkQualityInitResult Init(JNIEnv *env, AAssetManager *asset_manager,
                                   const char *storage_path,
                                   const char *asset_filename,
+                                  const vkqGraphicsAPIInfo *api_info,
                                   int32_t flags);
 
   static void DestroyInstance(JNIEnv *env);
@@ -69,7 +71,8 @@ class VkQualityManager {
   static std::string GetStaticStringField(JNIEnv *env, jclass clz,
                                           const char *name);
 
-  static vkQualityInitResult InitDeviceInfo(JNIEnv *env, DeviceInfo &device_info);
+  static vkQualityInitResult InitDeviceInfo(JNIEnv *env, DeviceInfo &device_info,
+                                            const vkqGraphicsAPIInfo *api_info);
 
   bool LoadCache(const DeviceInfo &device_info);
 
@@ -90,6 +93,7 @@ class VkQualityManager {
   JNIEnv *env_ = nullptr;
   std::string asset_filename_;
   std::string storage_path_;
+  const vkqGraphicsAPIInfo *api_info_ = nullptr;
 
   int32_t cache_list_version_ = -1;
   int32_t flags_ = 0;

--- a/vkq_library/vkquality/src/main/cpp/vulkan_util.cpp
+++ b/vkq_library/vkquality/src/main/cpp/vulkan_util.cpp
@@ -32,6 +32,22 @@ uint32_t VulkanUtil::GetVulkanApiVersionForApiLevel(const int device_api_level) 
   return VK_API_VERSION_1_0;
 }
 
+vkQualityInitResult VulkanUtil::CopyDeviceVulkanInfo(DeviceInfo &device_info,
+    void *vk_physical_device_properties) {
+    if (vk_physical_device_properties == nullptr) {
+      return kErrorNoVulkan;
+    }
+    const VkPhysicalDeviceProperties &device_properties =
+      *(reinterpret_cast<const VkPhysicalDeviceProperties *>(
+        vk_physical_device_properties));
+    device_info.vk_api_version = device_properties.apiVersion;
+    device_info.vk_driver_version = device_properties.driverVersion;
+    device_info.vk_device_id = device_properties.deviceID;
+    device_info.vk_vendor_id = device_properties.vendorID;
+    device_info.vk_device_name = device_properties.deviceName;
+    return kSuccess;
+}
+
 vkQualityInitResult VulkanUtil::GetDeviceVulkanInfo(DeviceInfo &device_info) {
   void *lib_vulkan = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
   if (lib_vulkan == nullptr) {

--- a/vkq_library/vkquality/src/main/cpp/vulkan_util.h
+++ b/vkq_library/vkquality/src/main/cpp/vulkan_util.h
@@ -23,6 +23,8 @@ namespace vkquality {
 
 class VulkanUtil {
  public:
+  static vkQualityInitResult CopyDeviceVulkanInfo(DeviceInfo &device_info,
+      void *vk_physical_device_properties);
   static vkQualityInitResult GetDeviceVulkanInfo(DeviceInfo &device_info);
   static uint32_t GetMinimumRecommendedVulkanVersion();
   static uint32_t GetVulkanApiVersionForApiLevel(const int device_api_level);


### PR DESCRIPTION
* Rebuilt library to be compatible with 16Kb page size Android devices. 
* Added `vkQuality_initializeFlagsInfo` alternative init function
for C/C++ users passing their own graphics device information instead of VkQuality
standing up graphics API instances to query.