### PR TITLE
Terminate EGL and destroy surface, context properly

### DIFF
--- a/vkq_library/vkquality/src/main/cpp/gles_util.cpp
+++ b/vkq_library/vkquality/src/main/cpp/gles_util.cpp
@@ -38,9 +38,15 @@ std::string GLESUtil::GetGLESVersionString() {
 
   EGLint config_count;
   if (eglChooseConfig(egl_display, config_attributes, &egl_config, 1, &config_count) != EGL_TRUE)
+  {
+    eglTerminate(egl_display);
     return result_string;
+  }
   if (config_count != 1)
+  {
+    eglTerminate(egl_display);
     return result_string;
+  }
 
   EGLint surfaceType = 0;
   eglGetConfigAttrib(egl_display, egl_config, EGL_SURFACE_TYPE, &surfaceType);
@@ -61,6 +67,7 @@ std::string GLESUtil::GetGLESVersionString() {
   const EGLint eglError = eglGetError();
   if (eglError != EGL_SUCCESS)
   {
+    eglTerminate(egl_display);
     return result_string;
   }
   const EGLint context_attribs[] = {EGL_CONTEXT_CLIENT_VERSION, 3, EGL_NONE};
@@ -68,15 +75,15 @@ std::string GLESUtil::GetGLESVersionString() {
   if (eglError != EGL_SUCCESS)
   {
     eglDestroySurface(egl_display, egl_surface);
+    eglTerminate(egl_display);
     return result_string;
   }
 
   if (eglMakeCurrent(egl_display, egl_surface, egl_surface, egl_context) == EGL_TRUE) {
     result_string = reinterpret_cast<const char*>(glGetString(GL_VERSION));
-    eglTerminate(egl_display);
+    eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
   }
 
-  eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
   eglDestroyContext(egl_display, egl_context);
   eglDestroySurface(egl_display, egl_surface);
   eglTerminate(egl_display);


### PR DESCRIPTION
I have crash at launch after adding vkquality into my Unity project.
```
E  validate_display:558 error 3001 (EGL_NOT_INITIALIZED)
A  Failed to create context, error = EGL_NOT_INITIALIZED
A  runtime.cc:708] Runtime aborting...
A  runtime.cc:708]   at java.lang.Object.wait(Object.java:405)
A  runtime.cc:708]   | held mutexes= "mutator lock"(shared held)
A  runtime.cc:708]   native: #23 pc 0077f5c4  /apex/com.android.art/lib64/libart.so (nterp_helper+3924) (BuildId: 27d824f901af23b82abd1f08138ee412)
A  runtime.cc:708]   at android.database.sqlite.SQLiteConnectionPool.tryAcquireNonPrimaryConnectionLocked(SQLiteConnectionPool.java:1355)
A  runtime.cc:708]   at android.database.CursorWrapper.close(CursorWrapper.java:54)
A  runtime.cc:708]   native: #01 pc 0002b9c0  /apex/com.android.art/lib64/libperfetto_hprof.so (void* std::__1::__thread_proxy[abi:nn180000]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, ArtPlugin_Initialize::$_7>>+308) (BuildId: d93f44fb8bbfdecc626adeb2d3da7219)
A  runtime.cc:708]   native: #01 pc 0009f494  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+160) (BuildId: 02a91a85343debb2911714273ff2b670)
A  runtime.cc:708]   native: #00 pc 000e8668  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+8) (BuildId: 02a91a85343debb2911714273ff2b670)
A  runtime.cc:708]   at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:506)
   runtime.cc:708]   | sysTid=2190 nice=-4 cgrp=default sched=0/0 handle=0x7882b3fcb0
A  runtime.cc:708]   native: #14 pc 000142d4  /system/lib64/libutils.so (android::Thread::_threadLoop+288) (BuildId: d0c24e3b7b6c7152eb82e77a5d2271e6)
   runtime.cc:708]   | sysTid=2190 nice=-4 cgrp=default sched=0/0 handle=0x7882b3fcb0
A  Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 2190 (RenderThread), pid 2155 (com.game.gp)
```

Then I try with Unity empty project, it works, but I spot the warning and errors below in logcat
```
W  eglTerminate() called w/ 2 objects remaining
E  validate_display:558 error 3001 (EGL_NOT_INITIALIZED)
E  eglMakeCurrentImpl:1001 error 3008 (EGL_BAD_DISPLAY)
E  validate_display:558 error 3001 (EGL_NOT_INITIALIZED)
E  validate_display:558 error 3001 (EGL_NOT_INITIALIZED)
```

It seems GetGLESVersionString() in gles_util.cpp terminates EGL incorrectly. I try to fix it and my project doesn't have crash anymore.